### PR TITLE
Add Union-Find tree

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/src/UnionFind.cpp
+++ b/src/UnionFind.cpp
@@ -6,6 +6,7 @@ class UnionFind {
 private:
   std::vector<int> disj;
   std::vector<int> rank;
+
 public:
   UnionFind(int n) : disj(n), rank(n) {
     for (int i = 0; i < n; ++i) {
@@ -30,11 +31,9 @@ public:
     } else {
       disj[y] = x;
       if (rank[x] == rank[y]) {
-	++rank[x];
+        ++rank[x];
       }
     }
   }
-  bool is_same_set(int x, int y) {
-    return root(x) == root(y);
-  }
+  bool is_same_set(int x, int y) { return root(x) == root(y); }
 };

--- a/src/UnionFind.cpp
+++ b/src/UnionFind.cpp
@@ -1,0 +1,40 @@
+/*
+ * Union-Find tree
+ * header requirement: vector
+ */
+class UnionFind {
+private:
+  std::vector<int> disj;
+  std::vector<int> rank;
+public:
+  UnionFind(int n) : disj(n), rank(n) {
+    for (int i = 0; i < n; ++i) {
+      disj[i] = i;
+      rank[i] = 0;
+    }
+  }
+  int root(int x) {
+    if (disj[x] == x) {
+      return x;
+    }
+    return disj[x] = root(disj[x]);
+  }
+  void unite(int x, int y) {
+    x = root(x);
+    y = root(y);
+    if (x == y) {
+      return;
+    }
+    if (rank[x] < rank[y]) {
+      disj[x] = y;
+    } else {
+      disj[y] = x;
+      if (rank[x] == rank[y]) {
+	++rank[x];
+      }
+    }
+  }
+  bool is_same_set(int x, int y) {
+    return root(x) == root(y);
+  }
+};


### PR DESCRIPTION
Closes https://github.com/comp-prog-jp-library-standard/competitive-programming-library/issues/2, and closes https://github.com/comp-prog-jp-library-standard/competitive-programming-library/issues/1.
Union-Find 木を追加しました。
変更や議論の余地がありそうなのは
- ファイルをどのディレクトリに置くか (今は `/src`)
- `int` の代わりに `size_t` を使うかどうか
- 必要なヘッダを示すためのマークアップなどを考える
- 関数名
- テストをどのように書くか
などだと思います。