### PR TITLE
Add files for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ addons:
     - llvm-toolchain-trusty-6.0
     packages:
     - clang-format-6.0
+env:
+  - CLANG_FORMAT=clang-format-6.0
 script:
   - ./travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 addons:
   apt:
     sources:
+    - ubuntu-toolchain-r-test
     - llvm-toolchain-trusty-6.0
     packages:
     - clang-format-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 addons:
   apt:
+    sources:
+    - llvm-toolchain-trusty-7
     packages:
-    - clang-format-6.0
+    - clang-format-7
 script:
   - ./travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 addons:
   apt:
     sources:
-    - llvm-toolchain-trusty-7
+    - llvm-toolchain-trusty-6.0
     packages:
-    - clang-format-7
+    - clang-format-6.0
 script:
   - ./travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+addons:
+  apt:
+    packages:
+    - clang-format-6.0
+script:
+  - ./travis-test.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# competitive-programming-library
+# competitive-programming-library [![Build Status](https://travis-ci.org/comp-prog-jp-library-standard/competitive-programming-library.svg?branch=master)](https://travis-ci.org/comp-prog-jp-library-standard/competitive-programming-library)

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,6 +1,6 @@
-#/bin/bash
+#!/bin/bash
 set -eux
-echo CLANG_FORMAT=$CLANG_FORMAT
+# CLANG_FORMAT is the name of clang-format command we want to use
 for src in `find . | grep -E "\.(cpp|h)$"`
 do
     diff -u $src <($CLANG_FORMAT $src) ||

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,5 +1,7 @@
 #/bin/bash
 set -eux
+which clang-format
+which clang-format-6.0
 for src in `find . | grep -E "\.(cpp|h)$"`
 do
     diff -u $src <(clang-format $src) ||

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -2,11 +2,11 @@
 # This script assumes that all files are already staged.
 # It formats all *.cpp, *.h files
 # and check if they become different from the original ones by using git diff.
-# ${CLANG_FORMAT} is the name of clang-format command we want to use
+# ${CLANG_FORMAT} is the name of clang-format command we want to use.
+# If not set, it defaults to "clang-format".
 if [ -z ${CLANG_FORMAT} ]
 then
-    echo 'Please set the variable ${CLANG_FORMAT}.' 1>&2
-    exit 1
+    CLANG_FORMAT=clang-format
 fi
 
 # All *.cpp/*.h files get formatted.

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,5 +1,5 @@
 #/bin/bash
-set -eu
+set -eux
 for src in `find . | grep -E "\.(cpp|h)$"`
 do
     diff -u $src <(clang-format $src) ||

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -4,5 +4,5 @@ set -eux
 for src in `find . | grep -E "\.(cpp|h)$"`
 do
     diff -u $src <($CLANG_FORMAT $src) ||
-        echo "Format error: clang-format for file $src" 1>&2
+        (echo "Format error: clang-format for file $src" 1>&2; exit 1)
 done

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,8 +1,35 @@
 #!/bin/bash
-set -eux
-# CLANG_FORMAT is the name of clang-format command we want to use
-for src in `find . | grep -E "\.(cpp|h)$"`
+# This script assumes that all files are already staged.
+# It formats all *.cpp, *.h files
+# and check if they become different from the original ones by using git diff.
+# ${CLANG_FORMAT} is the name of clang-format command we want to use
+if [ -z ${CLANG_FORMAT} ]
+then
+    echo 'Please set the variable ${CLANG_FORMAT}.' 1>&2
+    exit 1
+fi
+
+# All *.cpp/*.h files get formatted.
+SOURCE_FILES=`find . | grep -E "\.(cpp|h)$"`
+if ! ${CLANG_FORMAT} -i ${SOURCE_FILES}
+then
+    echo "${CLANG_FORMAT} failed" 1>&2
+    exit 1
+fi
+
+# If git diff finds a difference, print it.
+ERROR_COUNT=0
+for name in `git diff --name-only`
 do
-    diff -u $src <($CLANG_FORMAT $src) ||
-        (echo "Format error: clang-format for file $src" 1>&2; exit 1)
+    echo "File ${name} was ill-formatted and got formatted." 1>&2
+    git diff ${name} 1>&2
+    ERROR_COUNT=`expr ${ERROR_COUNT} + 1`
 done
+
+# Print a summary
+if [ ${ERROR_COUNT} -ne 0 ]
+then
+   echo "Error: ${ERROR_COUNT} file(s)" 1>&2
+   exit 1
+fi
+echo "OK"

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+set -eu
+for src in `find . | grep -E "\.(cpp|h)$"`
+do
+    diff -u $src <(clang-format $src) ||
+        echo "Format error: clang-format for file $src" 1>&2
+done

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,9 +1,8 @@
 #/bin/bash
 set -eux
-which clang-format
-which clang-format-6.0
+echo CLANG_FORMAT=$CLANG_FORMAT
 for src in `find . | grep -E "\.(cpp|h)$"`
 do
-    diff -u $src <(clang-format $src) ||
+    diff -u $src <($CLANG_FORMAT $src) ||
         echo "Format error: clang-format for file $src" 1>&2
 done


### PR DESCRIPTION
Closes https://github.com/comp-prog-jp-library-standard/competitive-programming-library/issues/5.
[Travis](https://travis-ci.org/comp-prog-jp-library-standard/competitive-programming-library) で CI を回せるようにしました。
CI の時にしたい処理がある場合は、 `travis-test.sh` に書いてください。
参考にしたレポジトリ: https://github.com/srajangarg/symengine/blob/d82f5a264b887853d20d745395b0f6a734918308/.travis.yml