### PR TITLE
Enclose in the namespace procon

### DIFF
--- a/src/UnionFind.cpp
+++ b/src/UnionFind.cpp
@@ -2,6 +2,7 @@
  * Union-Find tree
  * header requirement: vector
  */
+namespace procon {
 class UnionFind {
 private:
   std::vector<int> disj;
@@ -37,3 +38,4 @@ public:
   }
   bool is_same_set(int x, int y) { return root(x) == root(y); }
 };
+} // namespace procon


### PR DESCRIPTION
Fixes https://github.com/comp-prog-jp-library-standard/competitive-programming-library/issues/10.
名前空間 `procon` の中に入れました。
LLVM スタイルなので、名前空間のインデントはゼロです。http://llvm.org/docs/CodingStandards.html#namespace-indentation