### PR TITLE
非破壊フォーマッタを追加、スクリプトを bin/ に移動

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ addons:
 env:
   - CLANG_FORMAT=clang-format-6.0
 script:
-  - ./travis-test.sh
+  - bin/travis-test.sh

--- a/bin/auto-format.sh
+++ b/bin/auto-format.sh
@@ -32,4 +32,3 @@ then
    echo "Error: ${ERROR_COUNT} file(s)" 1>&2
    exit 1
 fi
-echo "OK"

--- a/bin/check-format.sh
+++ b/bin/check-format.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script checks whether all *.cpp, *.h files are correctly formatted.
+# This script does not make any changes to any files.
+# It just prints where is ill-formatted in a diff-like style.
+
+# CLANG_FORMAT is the name of clang-format command we want to use
+if [ -z ${CLANG_FORMAT} ]
+then
+    CLANG_FORMAT=clang-format
+fi
+set -u
+ERROR_COUNT=0
+for src in `find . | grep -E "\.(cpp|h)$"`
+do
+    if ! diff -u $src <(${CLANG_FORMAT} $src)
+    then
+        echo "Format error: ${CLANG_FORMAT} for file $src" 1>&2
+        ERROR_COUNT=`expr ${ERROR_COUNT} + 1`
+    fi
+done
+
+# Print a summary
+if [ ${ERROR_COUNT} -ne 0 ]
+then
+   echo "Error: ${ERROR_COUNT} file(s)" 1>&2
+   exit 1
+fi

--- a/bin/travis-test.sh
+++ b/bin/travis-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+DIRNAME=`dirname $0`
+${DIRNAME}/auto-format.sh
+echo OK


### PR DESCRIPTION
非破壊フォーマッタを `bin/check-format.sh` に追加し、今までの破壊フォーマッタを `bin/auto-format.sh` に置きました。
`travis-test.sh` も `bin/` に移動し、内部で `bin/auto-format.sh` を呼ぶようにしました。