### PR TITLE
セグメント木を追加

### DIFF
--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -48,6 +48,7 @@ public:
     return op(left, right);
   }
   value_type operator[](size_type idx) const { return dat[idx + n - 1]; }
+  size_type size() const { return n; }
 };
 } // namespace internal
 

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -1,3 +1,5 @@
+namespace procon {
+namespace internal {
 template <class I, class BiOp> class SegmentTree {
   int n;
   std::vector<I> dat;
@@ -47,3 +49,11 @@ public:
   }
   I operator[](int idx) const { return dat[idx + n - 1]; }
 };
+} // namespace internal
+
+template <class I, class BiOp>
+internal::SegmentTree<I, BiOp> make_segment_tree(int size, BiOp op, I e) {
+  internal::SegmentTree<I, BiOp> tree(size, op, std::move(e));
+  return tree;
+}
+} // namespace procon

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -5,6 +5,8 @@ template <class I, class BiOp> class SegmentTree {
   I e;
 
 public:
+  typedef int size_type;
+  typedef I value_type;
   SegmentTree(int n_, BiOp op, I e) : op(op), e(e) {
     n = 1;
     while (n < n_)
@@ -43,4 +45,5 @@ public:
     }
     return op(left, right);
   }
+  I operator[](int idx) const { return dat[idx + n - 1]; }
 };

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -1,87 +1,90 @@
 namespace procon {
 namespace internal {
-template <class I, class BiOp> class SegmentTree {
+template <class Op> class SegmentTree {
+  using I = typename Op::value_type;
   int n;
   std::vector<I> dat;
-  BiOp op;
-  I e;
 
 public:
   typedef int size_type;
-  typedef I value_type;
-  SegmentTree(size_type n_, BiOp op, value_type e) : op(op), e(e) {
+  SegmentTree(size_type n_) {
     n = 1;
     while (n < n_)
       n *= 2; // n is a power of 2
     dat.resize(2 * n);
     for (int i = 0; i < 2 * n - 1; i++) {
-      dat[i] = e;
+      dat[i] = Op::id;
     }
   }
   /* ary[k] <- v */
-  void update(size_type k, value_type v) {
+  void update(size_type k, typename Op::value_type v) {
     k += n - 1;
     dat[k] = v;
     while (k > 0) {
       k = (k - 1) / 2;
-      dat[k] = op(dat[2 * k + 1], dat[2 * k + 2]);
+      dat[k] = Op::op(dat[2 * k + 1], dat[2 * k + 2]);
     }
   }
   /* http://proc-cpuinfo.fixstars.com/2017/07/optimize-segment-tree/
    * [a, b)
    */
-  value_type query(size_type a, size_type b) const {
-    value_type left = e;
-    value_type right = e;
+  typename Op::value_type query(size_type a, size_type b) const {
+    typename Op::value_type left = Op::id;
+    typename Op::value_type right = Op::id;
     a += n - 1;
     b += n - 1;
     while (a < b) {
       if ((a & 1) == 0) {
-        left = op(left, dat[a]);
+        left = Op::op(left, dat[a]);
       }
       if ((b & 1) == 0) {
-        right = op(dat[b - 1], right);
+        right = Op::op(dat[b - 1], right);
       }
       a = a / 2;
       b = (b - 1) / 2;
     }
-    return op(left, right);
+    return Op::op(left, right);
   }
-  value_type operator[](size_type idx) const { return dat[idx + n - 1]; }
+  typename Op::value_type operator[](size_type idx) const {
+    return dat[idx + n - 1];
+  }
   size_type size() const { return n; }
 };
 
 template <class T> class generic_min {
 public:
-  T operator()(T x, T y) const { return std::min(x, y); }
+  using value_type = T;
+  static const T id = std::numeric_limits<T>::max();
+  static T op(T x, T y) { return std::min(x, y); }
 };
 
 template <class T> class generic_max {
 public:
-  T operator()(T x, T y) const { return std::max(x, y); }
+  using value_type = T;
+  static const T id = std::numeric_limits<T>::min();
+  static T op(T x, T y) { return std::max(x, y); }
+};
+
+template <class T> class generic_sum {
+public:
+  using value_type = T;
+  static const T id = 0;
+  static T op(T x, T y) { return x + y; }
 };
 } // namespace internal
 
-template <class I, class BiOp>
-internal::SegmentTree<I, BiOp> make_segment_tree(int size, BiOp op, I e) {
-  internal::SegmentTree<I, BiOp> tree(size, op, std::move(e));
-  return tree;
+template <class I>
+internal::SegmentTree<internal::generic_min<I>> make_range_min_query(int n) {
+  return internal::SegmentTree<internal::generic_min<I>>(n);
 }
 
 template <class I>
-internal::SegmentTree<I, internal::generic_min<I>>
-make_range_min_query(int n, I infinity) {
-  return make_segment_tree(n, internal::generic_min<I>(), infinity);
+internal::SegmentTree<internal::generic_max<I>> make_range_max_query(int n) {
+  return internal::SegmentTree<internal::generic_max<I>>(n);
 }
 
 template <class I>
-internal::SegmentTree<I, internal::generic_max<I>>
-make_range_max_query(int n, I negative_infinity) {
-  return make_segment_tree(n, internal::generic_max<I>(), negative_infinity);
-}
-
-template <class I>
-internal::SegmentTree<I, std::plus<I>> make_range_sum_query(int n, I zero) {
-  return make_segment_tree(n, std::plus<I>(), zero);
+internal::SegmentTree<internal::generic_sum<I>> make_range_sum_query(int n) {
+  return internal::SegmentTree<internal::generic_sum<I>>(n);
 }
 } // namespace procon

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -73,18 +73,22 @@ public:
   size_type size() const { return n; }
 };
 
+template <class I> using RangeMinQuery = SegmentTree<internal::generic_min<I>>;
+template <class I> using RangeMaxQuery = SegmentTree<internal::generic_max<I>>;
+template <class I> using RangeSumQuery = SegmentTree<internal::generic_sum<I>>;
+
 template <class I>
-internal::SegmentTree<internal::generic_min<I>> make_range_min_query(int n) {
-  return internal::SegmentTree<internal::generic_min<I>>(n);
+SegmentTree<internal::generic_min<I>> make_range_min_query(int n) {
+  return SegmentTree<internal::generic_min<I>>(n);
 }
 
 template <class I>
-internal::SegmentTree<internal::generic_max<I>> make_range_max_query(int n) {
-  return internal::SegmentTree<internal::generic_max<I>>(n);
+SegmentTree<internal::generic_max<I>> make_range_max_query(int n) {
+  return SegmentTree<internal::generic_max<I>>(n);
 }
 
 template <class I>
-internal::SegmentTree<internal::generic_sum<I>> make_range_sum_query(int n) {
-  return internal::SegmentTree<internal::generic_sum<I>>(n);
+SegmentTree<internal::generic_sum<I>> make_range_sum_query(int n) {
+  return SegmentTree<internal::generic_sum<I>>(n);
 }
 } // namespace procon

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -9,7 +9,7 @@ template <class I, class BiOp> class SegmentTree {
 public:
   typedef int size_type;
   typedef I value_type;
-  SegmentTree(int n_, BiOp op, I e) : op(op), e(e) {
+  SegmentTree(size_type n_, BiOp op, value_type e) : op(op), e(e) {
     n = 1;
     while (n < n_)
       n *= 2; // n is a power of 2
@@ -19,7 +19,7 @@ public:
     }
   }
   /* ary[k] <- v */
-  void update(int k, I v) {
+  void update(size_type k, value_type v) {
     k += n - 1;
     dat[k] = v;
     while (k > 0) {
@@ -30,9 +30,9 @@ public:
   /* http://proc-cpuinfo.fixstars.com/2017/07/optimize-segment-tree/
    * [a, b)
    */
-  I query(int a, int b) const {
-    I left = e;
-    I right = e;
+  value_type query(size_type a, size_type b) const {
+    value_type left = e;
+    value_type right = e;
     a += n - 1;
     b += n - 1;
     while (a < b) {
@@ -47,7 +47,7 @@ public:
     }
     return op(left, right);
   }
-  I operator[](int idx) const { return dat[idx + n - 1]; }
+  value_type operator[](size_type idx) const { return dat[idx + n - 1]; }
 };
 } // namespace internal
 

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -53,12 +53,12 @@ public:
 
 template <class T> class generic_min {
 public:
-  T operator()(T x, T y) const { return min(x, y); }
+  T operator()(T x, T y) const { return std::min(x, y); }
 };
 
 template <class T> class generic_max {
 public:
-  T operator()(T x, T y) const { return max(x, y); }
+  T operator()(T x, T y) const { return std::max(x, y); }
 };
 } // namespace internal
 
@@ -71,17 +71,17 @@ internal::SegmentTree<I, BiOp> make_segment_tree(int size, BiOp op, I e) {
 template <class I>
 internal::SegmentTree<I, internal::generic_min<I>>
 make_range_min_query(int n, I infinity) {
-  make_segment_tree(n, internal::generic_min<I>(), infinity);
+  return make_segment_tree(n, internal::generic_min<I>(), infinity);
 }
 
 template <class I>
 internal::SegmentTree<I, internal::generic_max<I>>
 make_range_max_query(int n, I negative_infinity) {
-  make_segment_tree(n, internal::generic_max<I>(), negative_infinity);
+  return make_segment_tree(n, internal::generic_max<I>(), negative_infinity);
 }
 
 template <class I>
 internal::SegmentTree<I, std::plus<I>> make_range_sum_query(int n, I zero) {
-  make_segment_tree(n, std::plus<I>(), zero);
+  return make_segment_tree(n, std::plus<I>(), zero);
 }
 } // namespace procon

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -1,23 +1,23 @@
 namespace procon {
 namespace internal {
 template <class Op> class SegmentTree {
-  using I = typename Op::value_type;
   int n;
-  std::vector<I> dat;
+  std::vector<typename Op::value_type> dat;
 
 public:
   typedef int size_type;
+  using value_type = typename Op::value_type;
   SegmentTree(size_type n_) {
     n = 1;
     while (n < n_)
       n *= 2; // n is a power of 2
-    dat.resize(2 * n);
+    dat.resize(2 * n, Op::id);
     for (int i = 0; i < 2 * n - 1; i++) {
       dat[i] = Op::id;
     }
   }
   /* ary[k] <- v */
-  void update(size_type k, typename Op::value_type v) {
+  void update(size_type k, value_type v) {
     k += n - 1;
     dat[k] = v;
     while (k > 0) {
@@ -28,7 +28,7 @@ public:
   /* http://proc-cpuinfo.fixstars.com/2017/07/optimize-segment-tree/
    * [a, b)
    */
-  typename Op::value_type query(size_type a, size_type b) const {
+  value_type query(size_type a, size_type b) const {
     typename Op::value_type left = Op::id;
     typename Op::value_type right = Op::id;
     a += n - 1;
@@ -45,25 +45,25 @@ public:
     }
     return Op::op(left, right);
   }
-  typename Op::value_type operator[](size_type idx) const {
-    return dat[idx + n - 1];
-  }
+  value_type operator[](size_type idx) const { return dat[idx + n - 1]; }
   size_type size() const { return n; }
 };
 
 template <class T> class generic_min {
 public:
   using value_type = T;
-  static const T id = std::numeric_limits<T>::max();
+  static const T id;
   static T op(T x, T y) { return std::min(x, y); }
 };
+template <class T> const T generic_min<T>::id = std::numeric_limits<T>::max();
 
 template <class T> class generic_max {
 public:
   using value_type = T;
-  static const T id = std::numeric_limits<T>::min();
+  static const T id;
   static T op(T x, T y) { return std::max(x, y); }
 };
+template <class T> const T generic_max<T>::id = std::numeric_limits<T>::min();
 
 template <class T> class generic_sum {
 public:

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -75,16 +75,4 @@ public:
 template <class I> using RangeMinQuery = SegmentTree<internal::generic_min<I>>;
 template <class I> using RangeMaxQuery = SegmentTree<internal::generic_max<I>>;
 template <class I> using RangeSumQuery = SegmentTree<internal::generic_sum<I>>;
-
-template <class I> RangeMinQuery<I> make_range_min_query(int n) {
-  return RangeMinQuery<I>(n);
-}
-
-template <class I> RangeMaxQuery<I> make_range_max_query(int n) {
-  return RangeMaxQuery<I>(n);
-}
-
-template <class I> RangeSumQuery<I> make_range_sum_query(int n) {
-  return RangeSumQuery<I>(n);
-}
 } // namespace procon

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -4,7 +4,7 @@ template <class T> class generic_min {
 public:
   using value_type = T;
   static const T id;
-  static T op(T x, T y) { return std::min(x, y); }
+  static const T &op(const T &x, const T &y) { return std::min(x, y); }
 };
 template <class T> const T generic_min<T>::id = std::numeric_limits<T>::max();
 
@@ -12,7 +12,7 @@ template <class T> class generic_max {
 public:
   using value_type = T;
   static const T id;
-  static T op(T x, T y) { return std::max(x, y); }
+  static const T &op(const T &x, const T &y) { return std::max(x, y); }
 };
 template <class T> const T generic_max<T>::id = std::numeric_limits<T>::min();
 
@@ -20,7 +20,7 @@ template <class T> class generic_sum {
 public:
   using value_type = T;
   static const T id = 0;
-  static T op(T x, T y) { return x + y; }
+  static T op(const T &x, const T &y) { return x + y; }
 };
 } // namespace internal
 

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -1,5 +1,29 @@
 namespace procon {
 namespace internal {
+template <class T> class generic_min {
+public:
+  using value_type = T;
+  static const T id;
+  static T op(T x, T y) { return std::min(x, y); }
+};
+template <class T> const T generic_min<T>::id = std::numeric_limits<T>::max();
+
+template <class T> class generic_max {
+public:
+  using value_type = T;
+  static const T id;
+  static T op(T x, T y) { return std::max(x, y); }
+};
+template <class T> const T generic_max<T>::id = std::numeric_limits<T>::min();
+
+template <class T> class generic_sum {
+public:
+  using value_type = T;
+  static const T id = 0;
+  static T op(T x, T y) { return x + y; }
+};
+} // namespace internal
+
 template <class Op> class SegmentTree {
   int n;
   std::vector<typename Op::value_type> dat;
@@ -48,30 +72,6 @@ public:
   value_type operator[](size_type idx) const { return dat[idx + n - 1]; }
   size_type size() const { return n; }
 };
-
-template <class T> class generic_min {
-public:
-  using value_type = T;
-  static const T id;
-  static T op(T x, T y) { return std::min(x, y); }
-};
-template <class T> const T generic_min<T>::id = std::numeric_limits<T>::max();
-
-template <class T> class generic_max {
-public:
-  using value_type = T;
-  static const T id;
-  static T op(T x, T y) { return std::max(x, y); }
-};
-template <class T> const T generic_max<T>::id = std::numeric_limits<T>::min();
-
-template <class T> class generic_sum {
-public:
-  using value_type = T;
-  static const T id = 0;
-  static T op(T x, T y) { return x + y; }
-};
-} // namespace internal
 
 template <class I>
 internal::SegmentTree<internal::generic_min<I>> make_range_min_query(int n) {

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -1,0 +1,46 @@
+template <class I, class BiOp> class SegmentTree {
+  int n;
+  std::vector<I> dat;
+  BiOp op;
+  I e;
+
+public:
+  SegmentTree(int n_, BiOp op, I e) : op(op), e(e) {
+    n = 1;
+    while (n < n_)
+      n *= 2; // n is a power of 2
+    dat.resize(2 * n);
+    for (int i = 0; i < 2 * n - 1; i++) {
+      dat[i] = e;
+    }
+  }
+  /* ary[k] <- v */
+  void update(int k, I v) {
+    k += n - 1;
+    dat[k] = v;
+    while (k > 0) {
+      k = (k - 1) / 2;
+      dat[k] = op(dat[2 * k + 1], dat[2 * k + 2]);
+    }
+  }
+  /* http://proc-cpuinfo.fixstars.com/2017/07/optimize-segment-tree/
+   * [a, b)
+   */
+  I query(int a, int b) const {
+    I left = e;
+    I right = e;
+    a += n - 1;
+    b += n - 1;
+    while (a < b) {
+      if ((a & 1) == 0) {
+        left = op(left, dat[a]);
+      }
+      if ((b & 1) == 0) {
+        right = op(dat[b - 1], right);
+      }
+      a = a / 2;
+      b = (b - 1) / 2;
+    }
+    return op(left, right);
+  }
+};

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -25,21 +25,20 @@ public:
 } // namespace internal
 
 template <class Op> class SegmentTree {
-  int n;
+  const int n;
   std::vector<typename Op::value_type> dat;
+  static int calculate_size(int n_) {
+    int n = 1;
+    while (n < n_)
+      n *= 2; // n is a power of 2
+    return n;
+  }
 
 public:
   typedef int size_type;
   using value_type = typename Op::value_type;
-  SegmentTree(size_type n_) {
-    n = 1;
-    while (n < n_)
-      n *= 2; // n is a power of 2
-    dat.resize(2 * n, Op::id);
-    for (int i = 0; i < 2 * n - 1; i++) {
-      dat[i] = Op::id;
-    }
-  }
+  SegmentTree(size_type size)
+      : n(calculate_size(size)), dat(2 * n - 1, Op::id) {}
   /* ary[k] <- v */
   void update(size_type k, value_type v) {
     k += n - 1;
@@ -77,18 +76,15 @@ template <class I> using RangeMinQuery = SegmentTree<internal::generic_min<I>>;
 template <class I> using RangeMaxQuery = SegmentTree<internal::generic_max<I>>;
 template <class I> using RangeSumQuery = SegmentTree<internal::generic_sum<I>>;
 
-template <class I>
-SegmentTree<internal::generic_min<I>> make_range_min_query(int n) {
-  return SegmentTree<internal::generic_min<I>>(n);
+template <class I> RangeMinQuery<I> make_range_min_query(int n) {
+  return RangeMinQuery<I>(n);
 }
 
-template <class I>
-SegmentTree<internal::generic_max<I>> make_range_max_query(int n) {
-  return SegmentTree<internal::generic_max<I>>(n);
+template <class I> RangeMaxQuery<I> make_range_max_query(int n) {
+  return RangeMaxQuery<I>(n);
 }
 
-template <class I>
-SegmentTree<internal::generic_sum<I>> make_range_sum_query(int n) {
-  return SegmentTree<internal::generic_sum<I>>(n);
+template <class I> RangeSumQuery<I> make_range_sum_query(int n) {
+  return RangeSumQuery<I>(n);
 }
 } // namespace procon

--- a/library/cpp/src/array/segment_tree.cpp
+++ b/library/cpp/src/array/segment_tree.cpp
@@ -50,11 +50,38 @@ public:
   value_type operator[](size_type idx) const { return dat[idx + n - 1]; }
   size_type size() const { return n; }
 };
+
+template <class T> class generic_min {
+public:
+  T operator()(T x, T y) const { return min(x, y); }
+};
+
+template <class T> class generic_max {
+public:
+  T operator()(T x, T y) const { return max(x, y); }
+};
 } // namespace internal
 
 template <class I, class BiOp>
 internal::SegmentTree<I, BiOp> make_segment_tree(int size, BiOp op, I e) {
   internal::SegmentTree<I, BiOp> tree(size, op, std::move(e));
   return tree;
+}
+
+template <class I>
+internal::SegmentTree<I, internal::generic_min<I>>
+make_range_min_query(int n, I infinity) {
+  make_segment_tree(n, internal::generic_min<I>(), infinity);
+}
+
+template <class I>
+internal::SegmentTree<I, internal::generic_max<I>>
+make_range_max_query(int n, I negative_infinity) {
+  make_segment_tree(n, internal::generic_max<I>(), negative_infinity);
+}
+
+template <class I>
+internal::SegmentTree<I, std::plus<I>> make_range_sum_query(int n, I zero) {
+  make_segment_tree(n, std::plus<I>(), zero);
 }
 } // namespace procon

--- a/library/cpp/src/template.cpp
+++ b/library/cpp/src/template.cpp
@@ -2,7 +2,11 @@
  * {{ LICENSE }}
  */
 
+#include <algorithm>
 #include <cassert>
+#include <cstdio>
 #include <iostream>
+#include <limits>
 #include <random>
+#include <utility>
 #include <vector>

--- a/library/cpp/tests/array/segment_tree/2431.cpp
+++ b/library/cpp/tests/array/segment_tree/2431.cpp
@@ -8,8 +8,7 @@ int main(void) {
   std::vector<int> x(n);
   for (int i = 0; i < n; ++i)
     scanf("%d", &x[i]);
-  auto seg =
-      procon::make_range_max_query(n + 1, std::numeric_limits<ll>::min());
+  auto seg = procon::make_range_max_query<ll>(n + 1);
   ll ma = 0;
   for (int i = 0; i < n; ++i) {
     ll res = std::max(seg.query(1, x[i]), 0LL);

--- a/library/cpp/tests/array/segment_tree/2431.cpp
+++ b/library/cpp/tests/array/segment_tree/2431.cpp
@@ -1,0 +1,22 @@
+// @depends_on library/cpp/src/array/segment_tree.cpp
+
+using ll = long long;
+
+int main(void) {
+  int n;
+  scanf("%d", &n);
+  std::vector<int> x(n);
+  for (int i = 0; i < n; ++i)
+    scanf("%d", &x[i]);
+  auto seg =
+      procon::make_range_max_query(n + 1, std::numeric_limits<ll>::min());
+  ll ma = 0;
+  for (int i = 0; i < n; ++i) {
+    ll res = std::max(seg.query(1, x[i]), 0LL);
+    ll cur = res + x[i];
+    ma = std::max(ma, cur);
+    seg.update(x[i], cur);
+  }
+  ll whole = (ll)n * (ll)(n + 1) / 2;
+  printf("%lld\n", whole - ma);
+}

--- a/library/cpp/tests/array/segment_tree/2431.cpp
+++ b/library/cpp/tests/array/segment_tree/2431.cpp
@@ -8,7 +8,7 @@ int main(void) {
   std::vector<int> x(n);
   for (int i = 0; i < n; ++i)
     scanf("%d", &x[i]);
-  auto seg = procon::make_range_max_query<ll>(n + 1);
+  auto seg = procon::RangeMaxQuery<ll>(n + 1);
   ll ma = 0;
   for (int i = 0; i < n; ++i) {
     ll res = std::max(seg.query(1, x[i]), 0LL);

--- a/library/cpp/tests/array/segment_tree/2431.yml
+++ b/library/cpp/tests/array/segment_tree/2431.yml
@@ -1,0 +1,3 @@
+download:
+  site: aoj
+  problem_id: "2431"

--- a/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
+++ b/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
@@ -3,8 +3,7 @@
 int main(void) {
   int n, q;
   scanf("%d%d", &n, &q);
-  int id = std::numeric_limits<int>::max();
-  auto seg = procon::make_range_min_query(n, id);
+  auto seg = procon::make_range_min_query<int>(n);
   while (q--) {
     int com, x, y;
     scanf("%d%d%d", &com, &x, &y);

--- a/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
+++ b/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
@@ -3,7 +3,7 @@
 int main(void) {
   int n, q;
   scanf("%d%d", &n, &q);
-  auto seg = procon::make_range_min_query<int>(n);
+  auto seg = procon::RangeMinQuery<int>(n);
   while (q--) {
     int com, x, y;
     scanf("%d%d%d", &com, &x, &y);

--- a/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
+++ b/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
@@ -3,9 +3,8 @@
 int main(void) {
   int n, q;
   scanf("%d%d", &n, &q);
-  auto op = [](int l, int r) { return std::min(l, r); };
   int id = std::numeric_limits<int>::max();
-  auto seg = procon::make_segment_tree(n, op, id);
+  auto seg = procon::make_range_min_query(n, id);
   while (q--) {
     int com, x, y;
     scanf("%d%d%d", &com, &x, &y);

--- a/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
+++ b/library/cpp/tests/array/segment_tree/DSL_2_A.cpp
@@ -1,0 +1,18 @@
+// @depends_on library/cpp/src/array/segment_tree.cpp
+
+int main(void) {
+  int n, q;
+  scanf("%d%d", &n, &q);
+  auto op = [](int l, int r) { return std::min(l, r); };
+  int id = std::numeric_limits<int>::max();
+  auto seg = procon::make_segment_tree(n, op, id);
+  while (q--) {
+    int com, x, y;
+    scanf("%d%d%d", &com, &x, &y);
+    if (com)
+      printf("%d\n", seg.query(x, y + 1));
+    else
+      seg.update(x, y);
+  }
+  return 0;
+}

--- a/library/cpp/tests/array/segment_tree/DSL_2_A.yml
+++ b/library/cpp/tests/array/segment_tree/DSL_2_A.yml
@@ -1,0 +1,3 @@
+download:
+  site: aoj
+  problem_id: DSL_2_A


### PR DESCRIPTION
Closes https://github.com/comp-prog-jp-library-standard/competitive-programming-library/issues/17.
`SegmentTree` という名前で、半開区間を受け取るセグメント木を作りました。
(Verified by https://agc007.contest.atcoder.jp/submissions/3392477)
- [x] テストを作る

設計について、
- データ型とそれの上の演算を別に渡す
- データ型に演算を含める
の2種類の方法が考えられますが、後者 (データ型に演算を含める) を採用します。
理由は以下の3点です。
- データ型と別に演算を渡す形式だと、演算の型をテンプレート引数に含める必要があり、書くのに手間がある
  - 参考: https://github.com/comp-prog-jp-library-standard/competitive-programming-library/blob/66e4f10321d3636c194f28cab25d9539aa81a9e4/library/cpp/src/array/segment_tree.cpp#L3
  - セグメント木であればまだ少ないが、遅延セグメント木などになると多くなる
- 型推論を働かせるためにヘルパー関数なども必要になる
  - こういうの https://github.com/comp-prog-jp-library-standard/competitive-programming-library/blob/ac854c5d8c796507cbb034ccc38b94414e9cf6c0/library/cpp/src/array/segment_tree.cpp#L65-L69
- 定義が1箇所にまとまっている方がわかりやすい
